### PR TITLE
Consolidate and rename agent modules with learning progression

### DIFF
--- a/src/pydantic_learning/__init__.py
+++ b/src/pydantic_learning/__init__.py
@@ -1,0 +1,3 @@
+"""PydanticAI Learning Hub - A progressive guide to building AI agents."""
+
+__version__ = "0.1.0"

--- a/src/pydantic_learning/agents/01_basic_agent.py
+++ b/src/pydantic_learning/agents/01_basic_agent.py
@@ -1,0 +1,31 @@
+"""Lesson 01: Basic Agent
+
+This is the simplest possible PydanticAI agent example.
+It demonstrates:
+- Creating an agent with a model
+- Setting basic instructions
+- Running a simple query
+
+Run with: uv run python -m pydantic_learning.agents.01_basic_agent
+"""
+
+import asyncio
+
+from pydantic_ai import Agent
+
+
+# Create a basic agent with instructions
+agent = Agent(
+    'anthropic:claude-3-5-haiku-latest',
+    instructions='You are a helpful assistant. Answer questions concisely.',
+)
+
+
+async def main():
+    """Run a simple agent query."""
+    result = await agent.run('What is PydanticAI?')
+    print(result.output)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/src/pydantic_learning/agents/02_agent_with_tools.py
+++ b/src/pydantic_learning/agents/02_agent_with_tools.py
@@ -1,0 +1,48 @@
+"""Lesson 02: Agent with Tools
+
+This example demonstrates how to give an agent tools (functions) it can call.
+It demonstrates:
+- Defining tools with the @agent.tool decorator
+- Tool parameters and return types
+- How agents decide when to use tools
+
+Run with: uv run python -m pydantic_learning.agents.02_agent_with_tools
+"""
+
+import asyncio
+from datetime import datetime
+
+from pydantic_ai import Agent, RunContext
+
+
+agent = Agent(
+    'anthropic:claude-3-5-haiku-latest',
+    instructions='You are a helpful assistant with access to utility tools.',
+)
+
+
+@agent.tool
+def get_current_time(ctx: RunContext) -> str:
+    """Get the current time in ISO format."""
+    return datetime.now().isoformat()
+
+
+@agent.tool
+def add_numbers(ctx: RunContext, a: int, b: int) -> int:
+    """Add two numbers together."""
+    return a + b
+
+
+async def main():
+    """Run queries that demonstrate tool usage."""
+    # Query that will use the time tool
+    result1 = await agent.run('What time is it right now?')
+    print(f"Time query: {result1.output}\n")
+
+    # Query that will use the math tool
+    result2 = await agent.run('What is 42 plus 17?')
+    print(f"Math query: {result2.output}")
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/src/pydantic_learning/agents/03_multi_agent.py
+++ b/src/pydantic_learning/agents/03_multi_agent.py
@@ -1,3 +1,14 @@
+"""Lesson 03: Multi-Agent System
+
+This example demonstrates a multi-agent system where agents interact with each other.
+It demonstrates:
+- Creating multiple agents with different roles
+- Agents calling other agents through tools
+- Coordinated game playing (twenty questions)
+
+Run with: uv run python -m pydantic_learning.agents.03_multi_agent
+"""
+
 import asyncio
 from dataclasses import dataclass
 from enum import StrEnum

--- a/src/pydantic_learning/agents/04_durable_dbos.py
+++ b/src/pydantic_learning/agents/04_durable_dbos.py
@@ -1,3 +1,15 @@
+"""Lesson 04: Durable Execution with DBOS
+
+This example demonstrates durable execution using DBOS.
+It demonstrates:
+- Wrapping agents with DBOSAgent for durability
+- Workflow persistence across restarts
+- Resume capability with workflow IDs
+
+Run with: uv run python -m pydantic_learning.agents.04_durable_dbos
+Resume with: uv run python -m pydantic_learning.agents.04_durable_dbos <workflow_id>
+"""
+
 import asyncio
 import sys
 import uuid

--- a/src/pydantic_learning/agents/05_durable_temporal.py
+++ b/src/pydantic_learning/agents/05_durable_temporal.py
@@ -1,3 +1,16 @@
+"""Lesson 05: Durable Execution with Temporal
+
+This example demonstrates durable execution using Temporal.
+It demonstrates:
+- Wrapping agents with TemporalAgent
+- Workflow definitions with @workflow.defn
+- Worker setup and execution
+- Resume capability with workflow IDs
+
+Run with: uv run python -m pydantic_learning.agents.05_durable_temporal
+Resume with: uv run python -m pydantic_learning.agents.05_durable_temporal <workflow_id>
+"""
+
 import asyncio
 import sys
 import uuid

--- a/src/pydantic_learning/agents/06_deep_research.py
+++ b/src/pydantic_learning/agents/06_deep_research.py
@@ -1,3 +1,15 @@
+"""Lesson 06: Deep Research - Advanced Multi-Agent Orchestration
+
+This example demonstrates complex multi-agent orchestration.
+It demonstrates:
+- Three-agent system: planner, searcher, analyzer
+- Parallel execution with asyncio.TaskGroup
+- Structured outputs with Pydantic models
+- Web search integration
+
+Run with: uv run python -m pydantic_learning.agents.06_deep_research
+"""
+
 import asyncio
 from typing import Annotated
 

--- a/src/pydantic_learning/agents/07_deep_research_dbos.py
+++ b/src/pydantic_learning/agents/07_deep_research_dbos.py
@@ -1,3 +1,15 @@
+"""Lesson 07: Deep Research with DBOS Durability
+
+This example demonstrates complex multi-agent orchestration with DBOS durability.
+It demonstrates:
+- Durable deep research workflow
+- Parallel workflow execution with DBOS
+- Resume capability for long-running research
+
+Run with: uv run python -m pydantic_learning.agents.07_deep_research_dbos
+Resume with: uv run python -m pydantic_learning.agents.07_deep_research_dbos <workflow_id>
+"""
+
 import asyncio
 import sys
 import uuid

--- a/src/pydantic_learning/agents/08_deep_research_temporal.py
+++ b/src/pydantic_learning/agents/08_deep_research_temporal.py
@@ -1,3 +1,16 @@
+"""Lesson 08: Deep Research with Temporal Durability
+
+This example demonstrates complex multi-agent orchestration with Temporal durability.
+It demonstrates:
+- Durable deep research workflow with Temporal
+- Parallel agent execution within Temporal workflows
+- Resume capability for long-running research
+- Custom activity timeouts
+
+Run with: uv run python -m pydantic_learning.agents.08_deep_research_temporal
+Resume with: uv run python -m pydantic_learning.agents.08_deep_research_temporal <workflow_id>
+"""
+
 import asyncio
 import os
 import sys

--- a/src/pydantic_learning/agents/09_evals.py
+++ b/src/pydantic_learning/agents/09_evals.py
@@ -1,3 +1,15 @@
+"""Lesson 09: Evaluation Patterns
+
+This example demonstrates how to evaluate agent performance.
+It demonstrates:
+- Using pydantic-evals for systematic testing
+- Creating evaluation datasets
+- Custom evaluators for metrics
+- Testing across multiple models
+
+Run with: uv run python -m pydantic_learning.agents.09_evals
+"""
+
 import asyncio
 from dataclasses import dataclass
 from typing import Any, TypedDict
@@ -7,7 +19,17 @@ from pydantic_ai import ModelResponse, TextPart, ToolCallPart, UsageLimitExceede
 from pydantic_ai.models import KnownModelName
 from pydantic_evals import Case, Dataset
 from pydantic_evals.evaluators import Evaluator, EvaluatorContext
-from twenty_questions import play, questioner_agent
+
+# Import the multi-agent example to evaluate
+# Note: Python modules can't start with numbers, so we use importlib
+import importlib.util
+import sys
+spec = importlib.util.spec_from_file_location("multi_agent", __file__.replace("09_evals.py", "03_multi_agent.py"))
+multi_agent = importlib.util.module_from_spec(spec)
+sys.modules["multi_agent"] = multi_agent
+spec.loader.exec_module(multi_agent)
+play = multi_agent.play
+questioner_agent = multi_agent.questioner_agent
 
 logfire.configure(console=False)
 logfire.instrument_pydantic_ai()

--- a/src/pydantic_learning/agents/__init__.py
+++ b/src/pydantic_learning/agents/__init__.py
@@ -1,0 +1,1 @@
+"""PydanticAI agent examples demonstrating progression from basic to advanced patterns."""


### PR DESCRIPTION
## Summary

Implements issue #3: Consolidates and renames agent modules into a clear learning progression.

## Changes

- Created new `src/pydantic_learning/agents/` directory structure
- Added two new introductory examples (01_basic_agent.py and 02_agent_with_tools.py)
- Reorganized existing agents into numbered sequence (03-09)
- Added comprehensive docstrings to each module
- Removed old `src/agents/` directory

## Learning Progression

1. **01_basic_agent.py** - Minimal agent example
2. **02_agent_with_tools.py** - Agent with tools
3. **03_multi_agent.py** - Multi-agent coordination (from twenty_questions.py)
4. **04_durable_dbos.py** - Durable execution with DBOS (from twenty_questions_dbos.py)
5. **05_durable_temporal.py** - Durable execution with Temporal (from twenty_questions_temporal.py)
6. **06_deep_research.py** - Advanced multi-agent orchestration (from deep_research.py)
7. **07_deep_research_dbos.py** - Durable deep research with DBOS (from deep_research_dbos.py)
8. **08_deep_research_temporal.py** - Durable deep research with Temporal (from deep_research_temporal.py)
9. **09_evals.py** - Evaluation patterns (from twenty_questions_evals.py)

Closes #3
Related to #1

🤖 Generated with [Claude Code](https://claude.ai/code)