### PR TITLE
feat: implement pydantic-settings based configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,41 @@
+# ===========================================
+# PydanticAI Learning - Environment Config
+# ===========================================
+
+# API Keys (required)
+OPENAI_API_KEY=sk-...
+ANTHROPIC_API_KEY=sk-ant-...
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
+TAVILY_API_KEY=tvly-...
+
+# ===========================================
+# Agent Model Configuration
+# ===========================================
+# All models default to openai:gpt-5-nano
+# Override per role if needed (optional)
+
+AGENT_DEFAULT_MODEL=openai:gpt-5-nano
+AGENT_ANSWERER_MODEL=openai:gpt-5-nano
+AGENT_QUESTIONER_MODEL=openai:gpt-5-nano
+AGENT_SEARCH_MODEL=openai:gpt-5-nano
+AGENT_ANALYSIS_MODEL=openai:gpt-5-nano
+
+# Model Settings
+AGENT_TEMPERATURE=0.7
+AGENT_MAX_TOKENS=4096
+AGENT_TIMEOUT=60.0
+
+# ===========================================
+# Infrastructure
+# ===========================================
+
+# Temporal (for durable execution)
+TEMPORAL_HOST=localhost:7233
+TEMPORAL_TASK_QUEUE=pydantic-learning
+
+# DBOS Database
+DBOS_DATABASE_URL=postgresql://postgres@localhost:5432/dbos
+
+# Observability
+LOGFIRE_ENABLED=true
+LOGFIRE_CONSOLE=false

--- a/src/pydantic_learning/__init__.py
+++ b/src/pydantic_learning/__init__.py
@@ -1,0 +1,10 @@
+"""PydanticAI Learning - Configuration and utilities."""
+
+from .config import AgentSettings, InfraSettings, get_agent_settings, get_infra_settings
+
+__all__ = [
+    'AgentSettings',
+    'InfraSettings',
+    'get_agent_settings',
+    'get_infra_settings',
+]

--- a/src/pydantic_learning/config.py
+++ b/src/pydantic_learning/config.py
@@ -1,0 +1,172 @@
+"""Central configuration for PydanticAI agents using pydantic-settings.
+
+This module provides environment-based configuration for all PydanticAI agents
+and infrastructure components used in the project.
+
+References:
+    - docs/pydantic_ai_best_practices.md - Configuration Management section
+    - https://docs.pydantic.dev/latest/concepts/pydantic_settings/
+"""
+
+from functools import lru_cache
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class AgentSettings(BaseSettings):
+    """Central configuration for all PydanticAI agents.
+
+    This class manages model selection and settings for different agent roles.
+    All settings can be overridden via environment variables with the AGENT_ prefix.
+
+    Environment Variables:
+        AGENT_DEFAULT_MODEL: Default model for general agents
+        AGENT_ANSWERER_MODEL: Model for answerer/responder agents
+        AGENT_QUESTIONER_MODEL: Model for questioner/planner agents
+        AGENT_SEARCH_MODEL: Model for search/web agents
+        AGENT_ANALYSIS_MODEL: Model for analysis/synthesis agents
+        AGENT_TEMPERATURE: Model temperature (0.0-2.0)
+        AGENT_MAX_TOKENS: Maximum tokens to generate
+        AGENT_TIMEOUT: Request timeout in seconds
+
+    Examples:
+        >>> settings = get_agent_settings()
+        >>> agent = Agent(settings.analysis_model, ...)
+
+        # Override via environment:
+        # AGENT_ANALYSIS_MODEL=anthropic:claude-opus-4-5 python my_app.py
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix='AGENT_',
+        env_file='.env',
+        env_file_encoding='utf-8',
+        extra='ignore',
+    )
+
+    # Default models for different agent roles
+    # All default to gpt-5-nano for consistency, override via environment
+    default_model: str = Field(
+        default='openai:gpt-5-nano',
+        description='Default model for general agents'
+    )
+    answerer_model: str = Field(
+        default='openai:gpt-5-nano',
+        description='Model for answerer/responder agents'
+    )
+    questioner_model: str = Field(
+        default='openai:gpt-5-nano',
+        description='Model for questioner/planner agents'
+    )
+    search_model: str = Field(
+        default='openai:gpt-5-nano',
+        description='Model for search/web agents'
+    )
+    analysis_model: str = Field(
+        default='openai:gpt-5-nano',
+        description='Model for analysis/synthesis agents'
+    )
+
+    # Model settings
+    temperature: float = Field(
+        default=0.7,
+        ge=0.0,
+        le=2.0,
+        description='Randomness: 0.0 = deterministic, 2.0 = very creative'
+    )
+    max_tokens: int = Field(
+        default=4096,
+        ge=1,
+        description='Maximum tokens to generate before stopping'
+    )
+    timeout: float = Field(
+        default=60.0,
+        ge=1.0,
+        description='Request timeout in seconds'
+    )
+
+
+class InfraSettings(BaseSettings):
+    """Infrastructure configuration for durable execution.
+
+    This class manages configuration for infrastructure components like
+    Temporal, DBOS (Postgres), and observability tools.
+
+    Environment Variables:
+        TEMPORAL_HOST: Temporal server host and port
+        TEMPORAL_TASK_QUEUE: Temporal task queue name
+        DBOS_DATABASE_URL: PostgreSQL connection URL for DBOS
+        LOGFIRE_ENABLED: Enable Logfire observability
+        LOGFIRE_CONSOLE: Enable Logfire console output
+
+    Examples:
+        >>> settings = get_infra_settings()
+        >>> # Use settings.temporal_host for Temporal connection
+    """
+
+    model_config = SettingsConfigDict(
+        env_file='.env',
+        env_file_encoding='utf-8',
+        extra='ignore',
+    )
+
+    # Temporal
+    temporal_host: str = Field(
+        default='localhost:7233',
+        description='Temporal server host and port'
+    )
+    temporal_task_queue: str = Field(
+        default='pydantic-learning',
+        description='Temporal task queue name'
+    )
+
+    # DBOS (Postgres)
+    dbos_database_url: str = Field(
+        default='postgresql://postgres@localhost:5432/dbos',
+        description='PostgreSQL connection URL for DBOS'
+    )
+
+    # Observability
+    logfire_enabled: bool = Field(
+        default=True,
+        description='Enable Logfire observability'
+    )
+    logfire_console: bool = Field(
+        default=False,
+        description='Enable Logfire console output'
+    )
+
+
+@lru_cache
+def get_agent_settings() -> AgentSettings:
+    """Get cached agent settings singleton.
+
+    This function uses LRU cache to ensure settings are loaded only once
+    and reused across the application.
+
+    Returns:
+        AgentSettings: Singleton instance of agent configuration
+
+    Examples:
+        >>> settings = get_agent_settings()
+        >>> agent = Agent(settings.analysis_model, ...)
+    """
+    return AgentSettings()
+
+
+@lru_cache
+def get_infra_settings() -> InfraSettings:
+    """Get cached infrastructure settings singleton.
+
+    This function uses LRU cache to ensure settings are loaded only once
+    and reused across the application.
+
+    Returns:
+        InfraSettings: Singleton instance of infrastructure configuration
+
+    Examples:
+        >>> settings = get_infra_settings()
+        >>> # Connect to Temporal using settings.temporal_host
+    """
+    return InfraSettings()


### PR DESCRIPTION
## Summary

Implements pydantic-settings based configuration system for PydanticAI agents as described in Issue #4.

## Changes

- Created `src/pydantic_learning/config.py` with AgentSettings and InfraSettings classes
- Added environment variable support with AGENT_ prefix
- Default all models to `openai:gpt-5-nano` for consistency
- Included configuration for Temporal, DBOS, and Logfire
- Created `.env.example` with comprehensive documentation
- Implemented singleton pattern with @lru_cache for settings

## Testing

The configuration module can be tested by:
1. Copying `.env.example` to `.env`
2. Importing and using the settings:
```python
from pydantic_learning.config import get_agent_settings
settings = get_agent_settings()
print(settings.analysis_model)
```

Resolves #4

🤖 Generated with [Claude Code](https://claude.ai/code)