### PR TITLE
Fix PydanticAI API compatibility issues in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,23 +2,54 @@
 
 This module provides fixtures for testing agents without making actual API calls.
 The ALLOW_MODEL_REQUESTS environment variable controls whether real API calls are allowed.
+
+Best Practices (per PydanticAI docs as of December 2025):
+- Use `TestModel` for unit tests without API calls
+- Use `agent.override(model=TestModel())` for testing existing agents
+- Set `models.ALLOW_MODEL_REQUESTS = False` to block real API calls globally
+- Use `custom_output_text` parameter for predefined responses
+- Use `@agent.tool_plain` for tools without RunContext access
+- Use `@agent.tool` for tools that need RunContext[DepsType]
 """
 
 import os
+import sys
+from pathlib import Path
 
 import pytest
-from pydantic_ai import Agent
+from pydantic_ai import Agent, models
 from pydantic_ai.models.test import TestModel
+
+# Add src directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+# Block all real model requests during tests (PydanticAI best practice)
+models.ALLOW_MODEL_REQUESTS = False
 
 
 @pytest.fixture
-def allow_model_requests() -> bool:
-    """Determine if real model requests are allowed during testing.
+def allow_model_requests():
+    """Fixture that enables real model requests for integration tests.
 
-    Returns:
-        bool: True if ALLOW_MODEL_REQUESTS is set to 'true', False otherwise
+    Use this fixture when you need to test against actual LLM APIs.
+    By default, all model requests are blocked (ALLOW_MODEL_REQUESTS=false).
+
+    Usage:
+        @pytest.mark.asyncio
+        async def test_with_real_api(allow_model_requests):
+            # Real API calls are now allowed for this test
+            ...
+
+    Yields:
+        bool: True if real requests were enabled, False otherwise
     """
-    return os.getenv('ALLOW_MODEL_REQUESTS', 'false').lower() == 'true'
+    should_allow = os.getenv('ALLOW_MODEL_REQUESTS', 'false').lower() == 'true'
+    if should_allow:
+        models.ALLOW_MODEL_REQUESTS = True
+        yield True
+        models.ALLOW_MODEL_REQUESTS = False
+    else:
+        yield False
 
 
 @pytest.fixture
@@ -51,15 +82,18 @@ def basic_test_agent(test_model: TestModel) -> Agent:
 
 
 @pytest.fixture
-def agent_with_custom_response(test_model: TestModel) -> callable:
+def agent_with_custom_response() -> callable:
     """Factory fixture for creating agents with custom test responses.
+
+    This follows PydanticAI best practices by using TestModel with custom_output_text.
 
     Returns:
         callable: A function that creates an agent with a predefined response
 
     Example:
         ```python
-        def test_something(agent_with_custom_response):
+        @pytest.mark.asyncio
+        async def test_something(agent_with_custom_response):
             agent = agent_with_custom_response("Custom response text")
             result = await agent.run("Test query")
             assert result.output == "Custom response text"
@@ -67,7 +101,36 @@ def agent_with_custom_response(test_model: TestModel) -> callable:
     """
 
     def _create_agent(response: str) -> Agent:
-        model = TestModel(custom_result_text=response)
+        model = TestModel(custom_output_text=response)
         return Agent(model, instructions='Test agent')
 
     return _create_agent
+
+
+@pytest.fixture
+def override_with_test_model():
+    """Factory fixture to override any agent's model with TestModel.
+
+    This is the recommended pattern from PydanticAI docs for testing
+    existing agents without modifying their source code.
+
+    Example:
+        ```python
+        from my_app import my_agent
+
+        @pytest.mark.asyncio
+        async def test_my_agent(override_with_test_model):
+            with override_with_test_model(my_agent):
+                result = await my_agent.run("test query")
+                assert result.output == 'success (no tool calls)'
+        ```
+    """
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _override(agent: Agent, custom_output_text: str | None = None):
+        test_model = TestModel(custom_output_text=custom_output_text)
+        with agent.override(model=test_model):
+            yield test_model
+
+    return _override


### PR DESCRIPTION
## Summary

Fixes test failures caused by PydanticAI API changes. All changes verified against official documentation (Context7, qdrant-docs) as of December 2025.

### Issues Fixed

| Issue | Before | After | Documentation Source |
|-------|--------|-------|---------------------|
| TestModel parameter | `custom_result_text` | `custom_output_text` | Context7 `/pydantic/pydantic-ai` |
| Tool decorator | `@agent.tool` (no context) | `@agent.tool_plain` | PydanticAI Function Tools docs |
| Internal API | `agent._function_tools` | `agent._function_toolset.tools` | Runtime inspection |
| Module imports | Not found | Added `src/` to `sys.path` | Standard Python practice |

### Best Practice Additions

Per PydanticAI official testing documentation:
- Added `models.ALLOW_MODEL_REQUESTS = False` globally to block real API calls
- Added `override_with_test_model` fixture using recommended `agent.override()` pattern
- Added docstring documenting testing best practices

### Grounding & Rationale

**TestModel API** (Context7 source):
```python
# Current API from /pydantic/pydantic-ai docs
model = TestModel(custom_output_text='Custom output')
```

**Tool Decorators** (PydanticAI Function Tools docs):
> "via the @agent.tool_plain decorator — for tools that do not need access to the agent context"

**Global Request Blocking** (PydanticAI Testing docs):
```python
models.ALLOW_MODEL_REQUESTS = False  # Block all real model requests during tests
```

## Test plan

- [x] All 6 tests pass: `uv run pytest -v`
- [x] Linting passes: `uv run ruff check tests/`
- [x] Changes verified against official PydanticAI documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)